### PR TITLE
support URL parameters and fix worker logic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,8 @@ You can try this [online](https://cristianvasquez.github.io/supernote-web-viewer
 
 All transformations occur directly in your browser (your notes remain private and are not transmitted to any server)
 
+You can also load a note automatically by passing a file URL via the `file` query parameter. This is useful for viewing notes synced to a private cloud, NAS, or other web-accessible storage. Note that for cross-origin requests, the hosting server must allow access.
+
 Sister app:
 This app is powered by the [supernote-typescript](https://github.com/philips/supernote-typescript/tree/main) library,
 which is

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,64 @@ function handleUploadClick() {
   document.getElementById('noteInput').click()
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+// Process note buffer from either file upload or URL fetch
+async function processNoteBuffer(arrayBuffer) {
+  const note = new SupernoteX(new Uint8Array(arrayBuffer))
+  const totalPages = note.pages.length
+
+  // Initialize the viewer with the total number of pages
+  viewer.initializePages(totalPages)
+
+  // Hide GitHub fork ribbon when viewing
+  const forkRibbon = document.querySelector('.github-fork-ribbon')
+  if (forkRibbon) {
+    forkRibbon.style.display = 'none'
+  }
+
+  // Clean up any existing workers
+  cleanupWorkers()
+
+  // Create workers and process pages
+  workers = Array(MAX_WORKERS).fill(null).map(() => new SupernoteWorker())
+  const processQueue = Array.from({ length: totalPages }, (_, i) => i + 1)
+
+  workers.forEach(worker => {
+    worker.onMessage(async ({ pageIndex, imageData, status, error }) => {
+      if (status === 'success') {
+        const base64Image = btoa(String.fromCharCode(...new Uint8Array(imageData)))
+        
+        // Get image dimensions
+        const img = new Image()
+        img.src = `data:image/png;base64,${base64Image}`
+        img.onload = () => {
+          viewer.addPageImage(pageIndex, base64Image, img.width, img.height)
+        }
+        img.onerror = (err) => {
+          console.error(`Error loading image for dimensions for page ${pageIndex}:`, err)
+          viewer.addPageImage(pageIndex, base64Image, 800, 600)
+        }
+      } else {
+        console.error(`Error processing page ${pageIndex}:`, error)
+      }
+
+      const nextPage = processQueue.shift()
+      if (nextPage) {
+        worker.process(note, nextPage)
+      }
+    })
+  })
+
+  workers.forEach(worker => {
+    const pageIndex = processQueue.shift()
+    if (pageIndex) worker.process(note, pageIndex)
+  })
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  // Check for ?file= URL parameter
+  const params = new URLSearchParams(window.location.search)
+  const fileUrl = params.get('file')
+
   // Initialize the SupernoteViewer with callbacks
   viewer = new SupernoteViewer({
     onProgress: (completed, total) => {
@@ -54,67 +111,32 @@ document.addEventListener('DOMContentLoaded', () => {
       // Page completed callback - could be used for additional processing
     },
     onUploadClick: handleUploadClick,
-    showUploadCard: true
+    showUploadCard: !fileUrl
   })
 
   // Set up upload click handler
   window.handleUploadClick = handleUploadClick
+
+  // Load file from URL if specified
+  if (fileUrl) {
+    updateStatus('Fetching file from URL...')
+    try {
+      const response = await fetch(fileUrl)
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const arrayBuffer = await response.arrayBuffer()
+      await processNoteBuffer(arrayBuffer)
+    } catch (err) {
+      console.error('Failed to load file from URL:', err)
+      updateStatus('Failed to load file from URL')
+    }
+  }
 
   document.getElementById('noteInput').addEventListener('change', async (event) => {
     const file = event.target.files[0]
     if (!file) return
 
     updateStatus('Loading file...')
-
     const arrayBuffer = await file.arrayBuffer()
-    const note = new SupernoteX(new Uint8Array(arrayBuffer))
-    const totalPages = note.pages.length
-
-    // Initialize the viewer with the total number of pages
-    viewer.initializePages(totalPages)
-
-    // Hide GitHub fork ribbon when viewing
-    const forkRibbon = document.querySelector('.github-fork-ribbon')
-    if (forkRibbon) {
-      forkRibbon.style.display = 'none'
-    }
-
-    // Clean up any existing workers
-    cleanupWorkers()
-
-    // Create workers and process pages
-    workers = Array(MAX_WORKERS).fill(null).map(() => new SupernoteWorker())
-    const processQueue = Array.from({ length: totalPages }, (_, i) => i + 1)
-
-    workers.forEach(worker => {
-      worker.onMessage(async ({ pageIndex, imageData, status, error }) => {
-        if (status === 'success') {
-          const base64Image = btoa(String.fromCharCode(...new Uint8Array(imageData)))
-          
-          // Get image dimensions
-          const img = new Image()
-          img.src = `data:image/png;base64,${base64Image}`
-          img.onload = () => {
-            viewer.addPageImage(pageIndex, base64Image, img.width, img.height)
-          }
-          img.onerror = (err) => {
-            console.error(`Error loading image for dimensions for page ${pageIndex}:`, err)
-            viewer.addPageImage(pageIndex, base64Image, 800, 600)
-          }
-        } else {
-          console.error(`Error processing page ${pageIndex}:`, error)
-        }
-
-        const nextPage = processQueue.shift()
-        if (nextPage) {
-          worker.process(note, nextPage)
-        }
-      })
-    })
-
-    workers.forEach(worker => {
-      const pageIndex = processQueue.shift()
-      if (pageIndex) worker.process(note, pageIndex)
-    })
+    await processNoteBuffer(arrayBuffer)
   })
 })


### PR DESCRIPTION
Thanks for making this!

The PR is to enable loading Supernote files via a `?file=` query parameter. This allows the viewer to be integrated into a personal file index or dashboard. For example, a user can create an HTML landing page that links to their notes synced to a private cloud or NAS.

It also fixes a bug in the `onMessage` handler where workers were instructed to re-process the current `pageIndex` instead of the `nextPage` from the queue.

README updated to mention passing a file URL via the `file` query parameter.